### PR TITLE
Set element styles safely

### DIFF
--- a/src/BetterSelect.ts
+++ b/src/BetterSelect.ts
@@ -317,7 +317,10 @@ export default class BetterSelect {
 
     // add the list to the dropdownEl
     dropdownEl.append(list);
-    dropdownEl.setAttribute('style', 'position: absolute; left: 0; top: 100%; right: 0;');
+    dropdownEl.style.position = "absolute";
+    dropdownEl.style.left = "0";
+    dropdownEl.style.top = "100%";
+    dropdownEl.style.right = "0";
     if (this.#dropdownEl) {
       this.#dropdownEl.replaceWith(dropdownEl);
     }


### PR DESCRIPTION
With a strict Content-Security-Policy set, styles set on an element's `style` attribute are blocked, unless they are set through the element's `style` *property* via JavaScript.[1]  Most of the better-select code is already doing this, but one piece of code was using the setAttribute() method, instead of setting CSS properties via the element's `style` attribute.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src